### PR TITLE
Add File Collection Script

### DIFF
--- a/p2a_impacts/resolver.py
+++ b/p2a_impacts/resolver.py
@@ -6,18 +6,7 @@ import logging
 from .parser import build_parse_tree
 from .evaluator import evaluate_rule
 from .fetch_data import get_dict_val, read_csv, get_variables
-
-
-def setup_logging(log_level):
-    formatter = logging.Formatter(
-        "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
-    )
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    logger = logging.getLogger("scripts")
-    logger.addHandler(handler)
-    logger.setLevel(getattr(logging, log_level))
-    return logger
+from .utils import setup_logging
 
 
 def resolve_rules(

--- a/p2a_impacts/utils.py
+++ b/p2a_impacts/utils.py
@@ -1,6 +1,6 @@
 import requests
 import csv
-
+import logging
 
 REGIONS = {
     "bc": "British Columbia",
@@ -91,3 +91,15 @@ def get_region(region_name, url):
     for row in csv_data:
         if row["english_na"] == region:
             return row
+
+
+def setup_logging(log_level):
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger = logging.getLogger("scripts")
+    logger.addHandler(handler)
+    logger.setLevel(getattr(logging, log_level))
+    return logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ GDAL==3.0.4
 numpy==1.16.0
 requests==2.24.0
 sly==0.3
+click==7.1.2 

--- a/scripts/file_collector.py
+++ b/scripts/file_collector.py
@@ -1,0 +1,181 @@
+"""
+The purpose of this script is to collect all the /storage/ filepaths used by
+the p2a_impacts package.
+"""
+
+from argparse import ArgumentParser
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import logging
+
+from ce.api.util import search_for_unique_ids
+from modelmeta import DataFile
+from p2a_impacts.parser import build_parse_tree
+from p2a_impacts.evaluator import evaluate_rule
+from p2a_impacts.fetch_data import (
+    get_dict_val,
+    read_csv,
+    translate_args,
+    get_models,
+)
+from p2a_impacts.utils import get_region, REGIONS
+
+
+def setup_logging(log_level):
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger = logging.getLogger("scripts")
+    logger.addHandler(handler)
+    logger.setLevel(getattr(logging, log_level))
+    return logger
+
+
+logger = setup_logging("INFO")
+
+
+def file_collection(csv, date_range, region, ensemble, connection_string):
+    """
+    Builds the variables that would be used in in p2a_impacts.resolve_rules
+    to the point of accessing the climate explorer database, but instead of evaluating
+    a rule it writes the paths for the files used to a text file.
+    """
+
+    # read csv
+    logger.info("Reading {}".format(csv))
+    rules = read_csv(csv)
+
+    # create parse tree dictionary and gather unique variables
+    logger.info("Building parse tree")
+    parse_trees = {}
+    variables = {}
+    region_variable = None
+    for rule, condition in rules.items():
+        try:
+            parse_trees[rule], vars, region_var = build_parse_tree(condition)
+        except SyntaxError as e:
+            logger.warning("{}, rule will be excluded".format(e))
+            continue
+
+        # check region var
+        if region_var:
+            region_variable = region_var
+
+        # add unique variables to set
+        for name, values in vars.items():
+            if name not in variables.keys():
+                variables[name] = values
+
+    # get values for all variables we would need if we were doing an evaluation
+    logger.info("Collecting variables")
+    Session = sessionmaker(create_engine(connection_string))
+    sesh = Session()
+
+    # write file paths for each variable to text file
+    for name, values in variables.items():
+        write_file_paths(sesh, values, ensemble, date_range, region)
+
+
+def write_file_paths(sesh, variables, ensemble, date_range, area):
+    """Given a variable name write the required file's path to file_paths.txt
+    by querying the CE backend.
+    """
+    logger.info("")
+    logger.info("Translating variables for query")
+    query_args = translate_args(
+        variables["variable"],
+        variables["time_of_year"],
+        variables["temporal"],
+        variables["spatial"],
+        variables["percentile"],
+        area,
+        date_range,
+        ensemble,
+    )
+
+    logger.info("Collecting models")
+    models = get_models(sesh, variables["percentile"], ensemble)
+
+    var_name = "_".join(
+        [
+            variables["variable"],
+            variables["time_of_year"],
+            variables["temporal"],
+            variables["spatial"],
+            variables["percentile"],
+        ]
+    )
+
+    logger.info("Fetching data for {}".format(var_name))
+
+    with open("/tmp/file_paths.txt", "a") as file_:
+        [file_.write(query_backend(sesh, model, query_args) + "\n") for model in models]
+        logger.info("Writing file path for {} to file".format(var_name))
+
+
+def query_backend(sesh, model, query_args):
+    """Return the desired file name for a particular climate model"""
+    logger.debug("Running query_backend() with args: %s, %s", model, query_args)
+    ids = [
+        search_for_unique_ids(
+            sesh,
+            ensemble_name=query_args["ensemble_name"],
+            model=model,
+            emission=query_args["emission"],
+            time=query_args["time"],
+            variable=var,
+            timescale=query_args["timescale"],
+            cell_method=query_args["cell_method"],
+        )
+        for var in query_args["variable"]
+    ]
+    for id_ in ids:
+        for model_id in list(id_):
+            data_file = (
+                sesh.query(DataFile).filter(DataFile.unique_id == model_id).one()
+            )
+            if data_file is not None:
+                return data_file.filename
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-c", "--csv", help="CSV file containing rules", default="./data/rules.csv",
+    )
+    parser.add_argument(
+        "-d",
+        "--date-range",
+        help="30 year period for data",
+        choices=["2020", "2050", "2080"],
+        default="2080",
+    )
+    parser.add_argument(
+        "-r", "--region", help="Selected region", default="bc", choices=REGIONS.keys()
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        help="Geoserver URL",
+        default="http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows",
+    )
+    parser.add_argument(
+        "-x",
+        "--connection-string",
+        help="Database connection string",
+        default="postgres://ce_meta_ro@db3.pcic.uvic.ca/ce_meta_12f290b63791",
+    )
+    parser.add_argument(
+        "-e",
+        "--ensemble",
+        help="Ensemble name filter for data files",
+        default="p2a_rules",
+    )
+    args = parser.parse_args()
+    region = get_region(args.region, args.url)
+
+    file_collection(
+        args.csv, args.date_range, region, args.ensemble, args.connection_string
+    )

--- a/scripts/file_collector.py
+++ b/scripts/file_collector.py
@@ -110,9 +110,13 @@ def write_file_paths(sesh, variables, ensemble, date_range, area):
 
     logger.info("Fetching data for {}".format(var_name))
 
-    with open("/tmp/file_paths.txt", "a") as file_:
-        [file_.write(query_backend(sesh, model, query_args) + "\n") for model in models]
-        logger.info("Writing file path for {} to file".format(var_name))
+    paths = []
+    [paths.extend(query_backend(sesh, model, query_args)) for model in models]
+    logger.info("Writing file path for {} to file".format(var_name))
+
+    with open("file_paths.txt", "a") as file_:
+        for path in paths:
+            file_.write(path + "\n")
 
 
 def query_backend(sesh, model, query_args):
@@ -131,13 +135,15 @@ def query_backend(sesh, model, query_args):
         )
         for var in query_args["variable"]
     ]
+    file_names = []
     for id_ in ids:
         for model_id in list(id_):
             data_file = (
                 sesh.query(DataFile).filter(DataFile.unique_id == model_id).one()
             )
             if data_file is not None:
-                return data_file.filename
+                file_names.append(data_file.filename)
+    return file_names
 
 
 if __name__ == "__main__":

--- a/scripts/file_collector.py
+++ b/scripts/file_collector.py
@@ -57,9 +57,7 @@ logger = setup_logging("INFO")
 @click.option(
     "-e", "--ensemble", help="Ensemble name filter for data files", default="p2a_rules"
 )
-@click.option(
-    "-f", "--output_file", help="Path to output file", default="/tmp/output.txt"
-)
+@click.option("-f", "--output_file", help="Path to output file", default="output.txt")
 def file_collection(
     csv, date_range, region, url, ensemble, connection_string, output_file
 ):
@@ -110,8 +108,8 @@ def file_collection(
 
     # write paths to file
     logger.info("Writing file paths to {}".format(output_file))
-    for file_ in file_paths:
-        with open(output_file, "a") as fout:
+    with open(output_file, "a") as fout:
+        for file_ in file_paths:
             fout.write(file_ + "\n")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,27 @@
 import pytest
+import py.path
+import tempfile
+from ce import get_app
+from datetime import datetime
+from pkg_resources import resource_filename
+from dateutil.relativedelta import relativedelta
+
+from modelmeta.v2 import (
+    metadata,
+    Ensemble,
+    Emission,
+    Model,
+    Run,
+    VariableAlias,
+    Grid,
+    Time,
+    TimeSet,
+    ClimatologicalTime,
+    DataFile,
+    DataFileVariableGridded,
+)
+from flask_sqlalchemy import SQLAlchemy
+from netCDF4 import Dataset
 
 
 @pytest.fixture(scope="function")
@@ -8,3 +31,222 @@ def ce_response():
         "test_period_20400101-20691231": {"mean": 3, "min": 1, "max": 5},
         "test_period_20700101-20991231": {"mean": 5, "min": 0, "max": 10},
     }
+
+
+@pytest.fixture(scope="function")
+def sessiondir(request,):
+    dir = py.path.local(tempfile.mkdtemp())
+    request.addfinalizer(lambda: dir.remove(rec=1))
+    return dir
+
+
+@pytest.fixture(scope="function")
+def dsn(sessiondir,):
+    return "sqlite:///{}".format(sessiondir.join("test.sqlite").realpath())
+
+
+@pytest.fixture
+def app(dsn,):
+    app = get_app()
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = dsn
+    app.config["SQLALCHEMY_ECHO"] = False
+    return app
+
+
+@pytest.fixture
+def cleandb(app,):
+    db = SQLAlchemy(app)
+    metadata.create_all(bind=db.engine)
+    db.create_all()
+    return db
+
+
+@pytest.fixture
+def populateddb(cleandb,):
+
+    now = datetime.utcnow()
+
+    populateable_db = cleandb
+    sesh = populateable_db.session
+
+    # Ensembles
+
+    p2a_rules = Ensemble(name="p2a_rules", version=1.0, changes="", description="",)
+    ensembles = [
+        p2a_rules,
+    ]
+
+    # Emissions
+
+    historical = Emission(short_name="historical")
+
+    # Runs
+
+    run3 = Run(name="r1i1p1", emission=historical,)
+
+    # Models
+
+    anusplin = Model(
+        short_name="anusplin",
+        long_name="Anusplin",
+        type="GCM",
+        runs=[run3],
+        organization="",
+    )
+    models = [
+        anusplin,
+    ]
+
+    # Data files
+
+    def make_data_file(
+        unique_id, filename=None, run=None,
+    ):
+        if not filename:
+            filename = "{}.nc".format(unique_id)
+        if not filename.startswith("/"):
+            filename = resource_filename("ce", "tests/data/{}".format(filename),)
+        return DataFile(
+            filename=filename,
+            unique_id=unique_id,
+            first_1mib_md5sum="xxxx",
+            x_dim_name="lon",
+            y_dim_name="lat",
+            index_time=now,
+            run=run,
+        )
+
+    df_6_seasonal = make_data_file(
+        unique_id="tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
+    )
+
+    data_files = [
+        df_6_seasonal,
+    ]
+
+    # VariableAlias
+
+    tasmin = VariableAlias(
+        long_name="Daily Minimum Temperature",
+        standard_name="air_temperature",
+        units="degC",
+    )
+    tasmax = VariableAlias(
+        long_name="Daily Maximum Temperature",
+        standard_name="air_temperature",
+        units="degC",
+    )
+    pr = VariableAlias(
+        long_name="Precipitation",
+        standard_name="precipitation_flux",
+        units="kg d-1 m-2",
+    )
+    flow_direction = VariableAlias(
+        long_name="Flow Direction", standard_name="flow_direction", units="1",
+    )
+    variable_aliases = [
+        tasmin,
+        tasmax,
+        pr,
+        flow_direction,
+    ]
+
+    # Grids
+
+    grid_anuspline = Grid(
+        name="Canada ANUSPLINE",
+        xc_grid_step=0.0833333,
+        yc_grid_step=0.0833333,
+        xc_origin=-140.958,
+        yc_origin=41.0417,
+        xc_count=1068,
+        yc_count=510,
+        xc_units="degrees_east",
+        yc_units="degrees_north",
+        evenly_spaced_y=True,
+    )
+    grids = [grid_anuspline]
+
+    # Add all the above
+
+    sesh.add_all(ensembles)
+    sesh.add_all(models)
+    sesh.add_all(data_files)
+    sesh.add_all(variable_aliases)
+    sesh.add_all(grids)
+    sesh.flush()
+
+    # DataFileVariable
+
+    def make_data_file_variable(
+        file, var_name=None, grid=grid_anuspline,
+    ):
+        var_name_to_alias = {
+            "tasmin": tasmin,
+            "tasmax": tasmax,
+            "pr": pr,
+            "flow_direction": flow_direction,
+        }[var_name]
+        variable_cell_methods = {
+            "tasmin": "time: minimum",
+            "tasmax": "time: maximum time: standard_deviation over days",
+            "pr": "time: mean time: mean over days",
+            "flow_direction": "foo",
+        }[var_name]
+        return DataFileVariableGridded(
+            file=file,
+            netcdf_variable_name=var_name,
+            range_min=0,
+            range_max=50,
+            variable_alias=var_name_to_alias,
+            grid=grid,
+            variable_cell_methods=variable_cell_methods,
+        )
+
+    tmax = make_data_file_variable(df_6_seasonal, var_name="tasmin",)
+
+    data_file_variables = [
+        tmax,
+    ]
+
+    sesh.add_all(data_file_variables)
+    sesh.flush()
+
+    # Associate to Ensembles
+
+    for dfv in data_file_variables:
+        p2a_rules.data_file_variables.append(dfv)
+    sesh.add_all(sesh.dirty)
+
+    # TimeSets
+
+    ts_seasonal = TimeSet(
+        calendar="gregorian",
+        start_date=datetime(1971, 1, 1,),
+        end_date=datetime(2000, 12, 31,),
+        multi_year_mean=True,
+        num_times=4,
+        time_resolution="seasonal",
+        times=[
+            Time(time_idx=i, timestep=datetime(1985, 3 * i + 1, 15,),) for i in range(4)
+        ],
+        climatological_times=[
+            ClimatologicalTime(
+                time_idx=i,
+                time_start=datetime(1971, 3 * i + 1, 1,) - relativedelta(months=1),
+                time_end=datetime(2000, 3 * i + 1, 1,)
+                + relativedelta(months=2)
+                - relativedelta(days=1),
+            )
+            for i in range(4)
+        ],
+    )
+    ts_seasonal.files = [
+        df_6_seasonal,
+    ]
+
+    sesh.add_all(sesh.dirty)
+
+    sesh.commit()
+    return populateable_db

--- a/tests/test_file_collector.py
+++ b/tests/test_file_collector.py
@@ -1,0 +1,42 @@
+import pytest
+from scripts.file_collector import get_paths_by_var
+
+# Most of file_collector's functionality is covered by test_fetch_data.py
+@pytest.mark.parametrize(
+    ("ensemble", "date", "area", "variables"),
+    (
+        [
+            "p2a_rules",
+            "2080",
+            {
+                "the_geom": """POLYGON((-122.70904541015625 49.31438004800689,
+            -122.92327880859375 49.35733376286064,-123.14849853515625
+            49.410973199695846,-123.34625244140625
+            49.30721745093609,-123.36273193359375
+            49.18170338770662,-123.20343017578125
+            49.005447494058096,-122.44537353515625
+            49.023461463214126,-122.46734619140625
+            49.13500260581219,-122.50579833984375
+            49.31079887964633,-122.70904541015625 49.31438004800689))"""
+            },
+            {
+                "temp_djf_iamean_s0p_hist": {
+                    "variable": "temp",
+                    "time_of_year": "djf",
+                    "temporal": "iamean",
+                    "spatial": "s0p",
+                    "percentile": "hist",
+                },
+            },
+        ],
+    ),
+)
+def test_get_paths_by_var(populateddb, ensemble, date, area, variables):
+    sesh = populateddb.session
+
+    for name, values in variables.items():
+        print(values)
+        paths = get_paths_by_var(sesh, values, ensemble, date, area)
+
+    for path in paths:
+        assert "/ce/tests/data/" in path

--- a/tests/test_file_collector.py
+++ b/tests/test_file_collector.py
@@ -1,5 +1,7 @@
 import pytest
 from scripts.file_collector import get_paths_by_var
+from p2a_impacts.utils import setup_logging
+
 
 # Most of file_collector's functionality is covered by test_fetch_data.py
 @pytest.mark.parametrize(
@@ -33,9 +35,10 @@ from scripts.file_collector import get_paths_by_var
 )
 def test_get_paths_by_var(populateddb, ensemble, date, area, variables):
     sesh = populateddb.session
+    logger = setup_logging("ERROR")
 
     for name, values in variables.items():
-        paths = get_paths_by_var(sesh, values, ensemble, date, area)
+        paths = get_paths_by_var(sesh, values, ensemble, date, area, logger)
 
     for path in paths:
         assert "/ce/tests/data/" in path

--- a/tests/test_file_collector.py
+++ b/tests/test_file_collector.py
@@ -35,7 +35,6 @@ def test_get_paths_by_var(populateddb, ensemble, date, area, variables):
     sesh = populateddb.session
 
     for name, values in variables.items():
-        print(values)
         paths = get_paths_by_var(sesh, values, ensemble, date, area)
 
     for path in paths:


### PR DESCRIPTION
The script `file_collector` builds the variables that would be used in in p2a_impacts.resolve_rules to the point of accessing the climate explorer database, but instead of evaluating a rule it writes the `/storage/` paths for the files used to a text file.

Resolves #28