### PR TITLE
I37 fix test

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not online"
+        py.test -m "not slow and not online"
     - name: Code format check
       run: |
         black . --check

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not slow and not online"
+        py.test -m "not online"
     - name: Code format check
       run: |
         black . --check

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ pre-commit==2.7.1
 pytest==6.0.2
 pytest-cov==2.10.1
 requests_mock==1.9
+mock==4.0.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from .mock_data import geoserver_data, tasmin_data, tasmax_data
 
 
 def create_modelmeta_objects():
-    """Create modelmeta objects used for both mock databases"""
+    """Create modelmeta objects used for both mock databases."""
 
     objects = {}
 
@@ -127,11 +127,12 @@ def make_data_file(
 def make_data_file_variable(
     file, cell_methods, variable_aliases, var_name=None, grid=None,
 ):
+    (tasmin, tasmax, pr, flow_direction) = variable_aliases[:]
     var_name_to_alias = {
-        "tasmin": variable_aliases[0],
-        "tasmax": variable_aliases[1],
-        "pr": variable_aliases[2],
-        "flow_direction": variable_aliases[3],
+        "tasmin": tasmin,
+        "tasmax": tasmax,
+        "pr": pr,
+        "flow_direction": flow_direction,
     }[var_name]
 
     return DataFileVariableGridded(
@@ -196,10 +197,13 @@ def cleandb(app,):
 
 @pytest.fixture()
 def populateddb_thredds(cleandb,):
+    """Create mock database only containing data files from THREDDS."""
 
     populateable_db = cleandb
     sesh = populateable_db.session
     objects = create_modelmeta_objects()
+    p2a_rules = objects["ensembles"][0]
+    grid_anuspline = objects["grids"][0]
 
     models = [objects["anusplin"], objects["canesm2"]]
 
@@ -275,35 +279,35 @@ def populateddb_thredds(cleandb,):
         cell_methods="time: minimum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmin",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmax_anusplin_seasonal = make_data_file_variable(
         df_anusplin_tasmax_seasonal,
         cell_methods="time: maximum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmax",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmin_anusplin_mon = make_data_file_variable(
         df_anusplin_tasmin_mon,
         cell_methods="time: minimum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmin",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmax_anusplin_mon = make_data_file_variable(
         df_anusplin_tasmax_mon,
         cell_methods="time: minimum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmax",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     pr_anusplin = make_data_file_variable(
         df_anusplin_pr_seasonal,
         cell_methods="time: mean time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="pr",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmin_canesm2_2050 = make_data_file_variable(
         df_canesm2_tasmin_2050_seasonal,
@@ -317,21 +321,21 @@ def populateddb_thredds(cleandb,):
         cell_methods="time: maximum",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmax",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmin_canesm2_2080 = make_data_file_variable(
         df_canesm2_tasmin_2080_seasonal,
         cell_methods="time: minimum",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmin",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmax_canesm2_2080 = make_data_file_variable(
         df_canesm2_tasmax_2080_seasonal,
         cell_methods="time: maximum",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmax",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     var_names = ("tmin", "tmax")
     data_file_variables = [
@@ -344,7 +348,7 @@ def populateddb_thredds(cleandb,):
     # Associate to Ensembles
 
     for dfv in data_file_variables:
-        objects["ensembles"][0].data_file_variables.append(dfv)
+        p2a_rules.data_file_variables.append(dfv)
     sesh.add_all(sesh.dirty)
 
     # TimeSets
@@ -453,10 +457,13 @@ def populateddb_thredds(cleandb,):
 
 @pytest.fixture()
 def populateddb_local(cleandb,):
+    """Create mock database only containing data files in this repository."""
 
     populateable_db = cleandb
     sesh = populateable_db.session
     objects = create_modelmeta_objects()
+    p2a_rules = objects["ensembles"][0]
+    grid_anuspline = objects["grids"][0]
 
     models = [objects["anusplin"]]
 
@@ -481,21 +488,21 @@ def populateddb_local(cleandb,):
     sesh.add_all(objects["grids"])
     sesh.flush()
 
-    # DataFileVariable
+    # DataFileVariables
 
     tmin_anusplin_seasonal = make_data_file_variable(
         df_anusplin_tasmin_seasonal,
         cell_methods="time: minimum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmin",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     tmax_anusplin_seasonal = make_data_file_variable(
         df_anusplin_tasmax_seasonal,
         cell_methods="time: maximum time: mean over days",
         variable_aliases=objects["variable_aliases"],
         var_name="tasmax",
-        grid=objects["grids"][0],
+        grid=grid_anuspline,
     )
     var_names = ("tmin", "tmax")
     data_file_variables = [v for k, v in locals().items() if k.startswith(var_names)]
@@ -506,7 +513,7 @@ def populateddb_local(cleandb,):
     # Associate to Ensembles
 
     for dfv in data_file_variables:
-        objects["ensembles"][0].data_file_variables.append(dfv)
+        p2a_rules.data_file_variables.append(dfv)
     sesh.add_all(sesh.dirty)
 
     # TimeSets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,28 @@ from flask_sqlalchemy import SQLAlchemy
 from .mock_data import geoserver_data, tasmin_data, tasmax_data
 
 
+# Functions to create data for database
+
+
+def make_data_file(
+    filename=None, run=None,
+):
+    if not filename.startswith("/"):
+        filename = resource_filename("tests", "data/{}".format(filename))
+    return DataFile(
+        filename=filename,
+        unique_id=filename,
+        first_1mib_md5sum="xxxx",
+        x_dim_name="lon",
+        y_dim_name="lat",
+        index_time=datetime.utcnow(),
+        run=run,
+    )
+
+
+# Fixtures
+
+
 @pytest.fixture
 def mock_thredds_url_root(monkeypatch):
     monkeypatch.setenv(
@@ -72,9 +94,7 @@ def cleandb(app,):
 
 
 @pytest.fixture
-def populateddb(cleandb,):
-
-    now = datetime.utcnow()
+def populateddb_thredds(cleandb,):
 
     populateable_db = cleandb
     sesh = populateable_db.session
@@ -87,41 +107,22 @@ def populateddb(cleandb,):
     ]
 
     # Emissions
+
     historical = Emission(short_name="historical")
     historical_rcp85 = Emission(short_name="historical,rcp85")
 
     # Runs
+
     run1 = Run(name="r1i1p1", emission=historical)
     run2 = Run(name="r1i1p1", emission=historical_rcp85)
 
     # Models
 
-    bnu = Model(short_name="BNU-ESM", type="GCM", runs=[run1], organization="BNU")
     anusplin = Model(short_name="anusplin", type="GCM", runs=[run1], organization="")
     canesm2 = Model(short_name="CanESM2", type="GCM", runs=[run2], organization="")
-    models = [bnu, anusplin, canesm2]
+    models = [anusplin, canesm2]
 
     # Data files
-
-    def make_data_file(
-        filename=None, run=None,
-    ):
-        if not filename.startswith("/"):
-            filename = resource_filename("ce", "tests/data/{}".format(filename))
-        return DataFile(
-            filename=filename,
-            unique_id=filename,
-            first_1mib_md5sum="xxxx",
-            x_dim_name="lon",
-            y_dim_name="lat",
-            index_time=now,
-            run=run,
-        )
-
-    df_bnu_seasonal = make_data_file(
-        filename="tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230.nc",
-        run=run1,
-    )  # Only local file (only used to test file collector). All other files from THREDDS.
 
     storage_root_anusplin = (
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
@@ -240,6 +241,7 @@ def populateddb(cleandb,):
             "pr": pr,
             "flow_direction": flow_direction,
         }[var_name]
+
         return DataFileVariableGridded(
             file=file,
             netcdf_variable_name=var_name,
@@ -250,9 +252,6 @@ def populateddb(cleandb,):
             variable_cell_methods=cell_methods,
         )
 
-    tmax_bnu = make_data_file_variable(
-        df_bnu_seasonal, cell_methods="time: maximum", var_name="tasmin",
-    )
     tmin_anusplin_seasonal = make_data_file_variable(
         df_anusplin_tasmin_seasonal,
         cell_methods="time: minimum time: mean over days",
@@ -397,7 +396,6 @@ def populateddb(cleandb,):
         ],
     )
     ts_hist_seasonal.files = [
-        df_bnu_seasonal,
         df_anusplin_tasmin_seasonal,
         df_anusplin_tasmax_seasonal,
         df_anusplin_pr_seasonal,
@@ -418,6 +416,169 @@ def populateddb(cleandb,):
 
 
 @pytest.fixture()
+def populateddb_local(cleandb,):
+
+    populateable_db = cleandb
+    sesh = populateable_db.session
+
+    # Ensembles
+
+    p2a_rules = Ensemble(name="p2a_rules", version=1.0, changes="", description="")
+    ensembles = [
+        p2a_rules,
+    ]
+
+    # Emissions
+
+    historical = Emission(short_name="historical")
+
+    # Runs
+
+    run1 = Run(name="r1i1p1", emission=historical)
+
+    # Models
+
+    anusplin = Model(short_name="anusplin", type="GCM", runs=[run1], organization="")
+    models = [anusplin]
+
+    # Data files
+
+    df_anusplin_tasmin_seasonal = make_data_file(
+        filename="tasmin_sClimMean_anusplin_historical_19710101-20001231.nc", run=run1,
+    )
+    df_anusplin_tasmax_seasonal = make_data_file(
+        filename="tasmax_sClimMean_anusplin_historical_19710101-20001231.nc", run=run1,
+    )
+    data_files = [v for k, v in locals().items() if k.startswith("df")]
+
+    # VariableAlias
+
+    tasmin = VariableAlias(
+        long_name="Daily Minimum Temperature",
+        standard_name="air_temperature",
+        units="degC",
+    )
+    tasmax = VariableAlias(
+        long_name="Daily Maximum Temperature",
+        standard_name="air_temperature",
+        units="degC",
+    )
+    pr = VariableAlias(
+        long_name="Precipitation",
+        standard_name="precipitation_flux",
+        units="kg d-1 m-2",
+    )
+    flow_direction = VariableAlias(
+        long_name="Flow Direction", standard_name="flow_direction", units="1",
+    )
+    variable_aliases = [
+        tasmin,
+        tasmax,
+        pr,
+        flow_direction,
+    ]
+
+    # Grids
+
+    grid_anuspline = Grid(
+        name="Canada ANUSPLINE",
+        xc_grid_step=0.0833333,
+        yc_grid_step=0.0833333,
+        xc_origin=-140.958,
+        yc_origin=41.0417,
+        xc_count=1068,
+        yc_count=510,
+        xc_units="degrees_east",
+        yc_units="degrees_north",
+        evenly_spaced_y=True,
+    )
+    grids = [grid_anuspline]
+
+    # Add all the above
+
+    sesh.add_all(ensembles)
+    sesh.add_all(models)
+    sesh.add_all(data_files)
+    sesh.add_all(variable_aliases)
+    sesh.add_all(grids)
+    sesh.flush()
+
+    # DataFileVariable
+
+    def make_data_file_variable(
+        file, cell_methods, var_name=None, grid=grid_anuspline,
+    ):
+        var_name_to_alias = {
+            "tasmin": tasmin,
+            "tasmax": tasmax,
+            "pr": pr,
+            "flow_direction": flow_direction,
+        }[var_name]
+
+        return DataFileVariableGridded(
+            file=file,
+            netcdf_variable_name=var_name,
+            range_min=0,
+            range_max=50,
+            variable_alias=var_name_to_alias,
+            grid=grid,
+            variable_cell_methods=cell_methods,
+        )
+
+    tmin_anusplin_seasonal = make_data_file_variable(
+        df_anusplin_tasmin_seasonal,
+        cell_methods="time: minimum time: mean over days",
+        var_name="tasmin",
+    )
+    tmax_anusplin_seasonal = make_data_file_variable(
+        df_anusplin_tasmax_seasonal,
+        cell_methods="time: maximum time: mean over days",
+        var_name="tasmax",
+    )
+    var_names = ("tmin", "tmax")
+    data_file_variables = [v for k, v in locals().items() if k.startswith(var_names)]
+
+    sesh.add_all(data_file_variables)
+    sesh.flush()
+
+    # Associate to Ensembles
+
+    for dfv in data_file_variables:
+        p2a_rules.data_file_variables.append(dfv)
+    sesh.add_all(sesh.dirty)
+
+    # TimeSets
+
+    ts_hist_seasonal = TimeSet(
+        calendar="standard",
+        start_date=datetime(1971, 1, 1),
+        end_date=datetime(2000, 12, 31),
+        multi_year_mean=True,
+        num_times=4,
+        time_resolution="seasonal",
+        times=[
+            Time(time_idx=i, timestep=datetime(1986, 3 * i + 1, 16)) for i in range(4)
+        ],
+        climatological_times=[
+            ClimatologicalTime(
+                time_idx=i,
+                time_start=datetime(1971, 3 * i + 1, 1) - relativedelta(months=1),
+                time_end=datetime(2000, 3 * i + 1, 1) + relativedelta(months=2),
+            )
+            for i in range(4)
+        ],
+    )
+    ts_hist_seasonal.files = [
+        df_anusplin_tasmin_seasonal,
+        df_anusplin_tasmax_seasonal,
+    ]
+    sesh.add_all(sesh.dirty)
+
+    sesh.commit()
+    return populateable_db
+
+
+@pytest.fixture()
 def mock_urls(requests_mock):
     requests_mock.register_uri(
         "GET",
@@ -426,14 +587,14 @@ def mock_urls(requests_mock):
     )
     requests_mock.register_uri(
         "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmin_data,
     )
     requests_mock.register_uri(
         "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmax_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmax_data,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,24 +587,10 @@ def mock_urls(requests_mock):
     )
     requests_mock.register_uri(
         "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
-        "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
-        "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
-        content=tasmin_data,
-    )
-    requests_mock.register_uri(
-        "GET",
         "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmin_data,
-    )
-    requests_mock.register_uri(
-        "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
-        "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
-        "tasmax_sClimMean_anusplin_historical_19710101-20001231.nc",
-        content=tasmax_data,
     )
     requests_mock.register_uri(
         "GET",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from .mock_data import geoserver_data, tasmin_data, tasmax_data
 def mock_thredds_url_root(monkeypatch):
     monkeypatch.setenv(
         "THREDDS_URL_ROOT",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,10 +587,24 @@ def mock_urls(requests_mock):
     )
     requests_mock.register_uri(
         "GET",
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
+        "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
+        "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
+        content=tasmin_data,
+    )
+    requests_mock.register_uri(
+        "GET",
         "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmin_data,
+    )
+    requests_mock.register_uri(
+        "GET",
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
+        "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
+        "tasmax_sClimMean_anusplin_historical_19710101-20001231.nc",
+        content=tasmax_data,
     )
     requests_mock.register_uri(
         "GET",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from .mock_data import geoserver_data, tasmin_data, tasmax_data
 def mock_thredds_url_root(monkeypatch):
     monkeypatch.setenv(
         "THREDDS_URL_ROOT",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets",
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
     )
 
 
@@ -426,14 +426,14 @@ def mock_urls(requests_mock):
     )
     requests_mock.register_uri(
         "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmin_data,
     )
     requests_mock.register_uri(
         "GET",
-        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets"
         "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
         "tasmax_sClimMean_anusplin_historical_19710101-20001231.nc",
         content=tasmax_data,

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -1,4 +1,5 @@
 from pkg_resources import resource_filename
+from netCDF4 import Dataset
 
 geoserver_data = open(resource_filename("tests", "data/geoserver_van.txt"), "rb").read()
 
@@ -10,5 +11,7 @@ def get_nc_data(filename):
     return filedata
 
 
-tasmin_data = get_nc_data("tasmin_sClimMean_anusplin_historical_19710101-20001231.nc")
-tasmax_data = get_nc_data("tasmax_sClimMean_anusplin_historical_19710101-20001231.nc")
+tasmin_filename = "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
+tasmax_filename = "tasmax_sClimMean_anusplin_historical_19710101-20001231.nc"
+tasmin_data = get_nc_data(tasmin_filename)
+tasmax_data = get_nc_data(tasmax_filename)

--- a/tests/test_file_collector.py
+++ b/tests/test_file_collector.py
@@ -33,12 +33,12 @@ from p2a_impacts.utils import setup_logging
         ],
     ),
 )
-def test_get_paths_by_var(populateddb, ensemble, date, area, variables):
-    sesh = populateddb.session
+def test_get_paths_by_var(populateddb_local, ensemble, date, area, variables):
+    sesh = populateddb_local.session
     logger = setup_logging("ERROR")
 
     for name, values in variables.items():
         paths = get_paths_by_var(sesh, values, ensemble, date, area, False, logger)
 
     for path in paths:
-        assert "/ce/tests/data/" in path or "/storage/data/" in path
+        assert "p2a-rule-engine/tests/data/" in path

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -27,7 +27,6 @@ def test_mock_opendap_request(mock_opendap_request, mock_thredds_url_root):
     assert mock_opendap_request.call_count == 2
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     ("csv", "date_range", "region", "geoserver", "ensemble", "thredds"),
     [
@@ -132,7 +131,6 @@ def test_resolve_rules_multi_var(
     assert round(rules["rule_shm"], 3) == expected_rules["rule_shm"]
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     ("csv", "date_range", "region", "geoserver", "ensemble", "thredds"),
     [

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,6 +3,8 @@ from pkg_resources import resource_filename
 
 from p2a_impacts.resolver import resolve_rules
 from p2a_impacts.utils import get_region
+
+import os
 import requests
 from .mock_data import tasmin_data
 
@@ -136,11 +138,11 @@ def test_resolve_rules_local(
     assert rules == expected_rules
 
 
-def test_mock_urls(mock_urls):
+def test_mock_urls(mock_thredds_url_root, mock_urls):
     assert (
         requests.get(
-            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
-            "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
+            os.getenv("THREDDS_URL_ROOT")
+            + "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
             "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
         ).content
         == tasmin_data

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,7 +6,25 @@ from p2a_impacts.utils import get_region
 
 import os
 import requests
-from .mock_data import tasmin_data
+import mock
+import netCDF4
+from netCDF4 import Dataset
+from .mock_data import tasmin_data, tasmax_data
+
+
+def mock_opendap_request(path, mode="r"):
+    return Dataset(resource_filename("tests", f"data/{os.path.basename(path)}"), "r")
+
+
+@mock.patch("netCDF4.Dataset", side_effect=mock_opendap_request)
+def test_mock_opendap_request(mock_opendap_request):
+    base_path_tasmin = "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
+    dods_path_tasmin = os.getenv("THREDDS_URL_ROOT") + base_path_tasmin
+    tasmin = netCDF4.Dataset(dods_path_tasmin)
+    base_path_tasmax = "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/tasmax_sClimMean_anusplin_historical_19710101-20001231.nc"
+    dods_path_tasmax = os.getenv("THREDDS_URL_ROOT") + base_path_tasmax
+    tasmax = netCDF4.Dataset(dods_path_tasmax)
+    assert mock_opendap_request.call_count == 2
 
 
 @pytest.mark.slow
@@ -23,7 +41,9 @@ from .mock_data import tasmin_data
         ),
     ],
 )
+@mock.patch("ce.api.util.Dataset", side_effect=mock_opendap_request)
 def test_resolve_rules_basic(
+    mock_opendap_request,
     populateddb_thredds,
     mock_thredds_url_root,
     mock_urls,
@@ -138,11 +158,15 @@ def test_resolve_rules_local(
 
 
 def test_mock_urls(mock_thredds_url_root, mock_urls):
-    assert (
-        requests.get(
-            os.getenv("THREDDS_URL_ROOT")
-            + "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
-            "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
-        ).content
-        == tasmin_data
+    base_path_tasmin = "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
+    fileserver_path_tasmin = (
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
+        + base_path_tasmin
     )
+    base_path_tasmax = "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/tasmax_sClimMean_anusplin_historical_19710101-20001231.nc"
+    fileserver_path_tasmax = (
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
+        + base_path_tasmax
+    )
+    assert requests.get(fileserver_path_tasmin).content == tasmin_data
+    assert requests.get(fileserver_path_tasmax).content == tasmax_data

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -17,7 +17,7 @@ def mock_opendap_request(path, mode="r"):
 
 
 @mock.patch("netCDF4.Dataset", side_effect=mock_opendap_request)
-def test_mock_opendap_request(mock_opendap_request):
+def test_mock_opendap_request(mock_opendap_request, mock_thredds_url_root):
     base_path_tasmin = "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
     dods_path_tasmin = os.getenv("THREDDS_URL_ROOT") + base_path_tasmin
     tasmin = netCDF4.Dataset(dods_path_tasmin)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -113,7 +113,6 @@ def test_resolve_rules_multi_var(
 
 
 @pytest.mark.slow
-@pytest.mark.online
 @pytest.mark.parametrize(
     ("csv", "date_range", "region", "geoserver", "ensemble", "thredds"),
     [
@@ -128,7 +127,7 @@ def test_resolve_rules_multi_var(
     ],
 )
 def test_resolve_rules_local(
-    populateddb_local, csv, date_range, region, geoserver, ensemble, thredds,
+    populateddb_local, mock_urls, csv, date_range, region, geoserver, ensemble, thredds,
 ):
     sesh = populateddb_local.session
     rules = resolve_rules(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,6 +3,8 @@ from pkg_resources import resource_filename
 
 from p2a_impacts.resolver import resolve_rules
 from p2a_impacts.utils import get_region
+import requests
+from .mock_data import tasmin_data
 
 
 @pytest.mark.slow
@@ -132,3 +134,14 @@ def test_resolve_rules_local(
     )
     expected_rules = {"rule_snow": True, "rule_hybrid": True, "rule_rain": True}
     assert rules == expected_rules
+
+
+def test_mock_urls(mock_urls):
+    assert (
+        requests.get(
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets"
+            "/storage/data/climate/downscale/BCCAQ2/ANUSPLIN/climatologies/"
+            "tasmin_sClimMean_anusplin_historical_19710101-20001231.nc"
+        ).content
+        == tasmin_data
+    )

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -20,7 +20,7 @@ from p2a_impacts.utils import get_region
     ],
 )
 def test_resolve_rules_basic(
-    populateddb,
+    populateddb_thredds,
     mock_thredds_url_root,
     mock_urls,
     csv,
@@ -30,7 +30,7 @@ def test_resolve_rules_basic(
     ensemble,
     thredds,
 ):
-    sesh = populateddb.session
+    sesh = populateddb_thredds.session
     rules = resolve_rules(
         csv, date_range, get_region(region, geoserver), ensemble, sesh, thredds
     )
@@ -54,7 +54,7 @@ def test_resolve_rules_basic(
 )
 @pytest.mark.parametrize("date_range", ["2050", "2080"])
 def test_resolve_rules_multi_percentile(
-    populateddb,
+    populateddb_thredds,
     mock_thredds_url_root,
     csv,
     date_range,
@@ -63,7 +63,7 @@ def test_resolve_rules_multi_percentile(
     ensemble,
     thredds,
 ):
-    sesh = populateddb.session
+    sesh = populateddb_thredds.session
     rules = resolve_rules(
         csv, date_range, get_region(region, geoserver), ensemble, sesh, thredds
     )
@@ -91,7 +91,7 @@ def test_resolve_rules_multi_percentile(
     ],
 )
 def test_resolve_rules_multi_var(
-    populateddb,
+    populateddb_thredds,
     mock_thredds_url_root,
     csv,
     date_range,
@@ -100,9 +100,35 @@ def test_resolve_rules_multi_var(
     ensemble,
     thredds,
 ):
-    sesh = populateddb.session
+    sesh = populateddb_thredds.session
     rules = resolve_rules(
         csv, date_range, get_region(region, geoserver), ensemble, sesh, thredds
     )
     expected_rules = {"rule_shm": 65.807}
     assert round(rules["rule_shm"], 3) == expected_rules["rule_shm"]
+
+
+@pytest.mark.slow
+@pytest.mark.online
+@pytest.mark.parametrize(
+    ("csv", "date_range", "region", "geoserver", "ensemble", "thredds"),
+    [
+        (
+            resource_filename("tests", "data/rules-basic.csv"),
+            "hist",
+            "vancouver_island",
+            "http://docker-dev01.pcic.uvic.ca:30123/geoserver/bc_regions/ows",
+            "p2a_rules",
+            False,
+        ),
+    ],
+)
+def test_resolve_rules_local(
+    populateddb_local, csv, date_range, region, geoserver, ensemble, thredds,
+):
+    sesh = populateddb_local.session
+    rules = resolve_rules(
+        csv, date_range, get_region(region, geoserver), ensemble, sesh, thredds
+    )
+    expected_rules = {"rule_snow": True, "rule_hybrid": True, "rule_rain": True}
+    assert rules == expected_rules


### PR DESCRIPTION
This PR resolves #37. The OPeNDAP requests in `test_resolve_rules_basic` were mocked out using `mock.patch` instead of `requests.mock` so that `netCDF4.Dataset` would be called using local data files instead of THREDDS files. Additionally, separate databases are used to differentiate between local files and THREDDS files so that automated tests using THREDDS files do not query local files and vice versa.